### PR TITLE
Fix "require" line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 Load the extension in you tests which need it
 
 ```ruby
-require "active_merchant-paypal-bogus-gateway/ext/paypal_bogus_gateway"
+require "active_merchant/ext/paypal_bogus_gateway"
 
 ActiveMerchant::Billing::PaypalBogusGateway.new
 ```


### PR DESCRIPTION
The current line in the docs didn't work for me, but this one does.
